### PR TITLE
fixed #1

### DIFF
--- a/cabocha.gemspec
+++ b/cabocha.gemspec
@@ -1,12 +1,8 @@
 # coding: utf-8
 
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'cabocha'
-
 Gem::Specification.new do |spec|
   spec.name          = 'cabocha'
-  spec.version       = CaboCha::VERSION
+  spec.version       = '0.69-1'
   spec.authors       = ['Yasuaki Uechi']
   spec.email         = ['uetchy@randompaper.co']
   spec.summary       = %q{cabocha-ruby is a gem that provides Ruby bindings for CaboCha.}

--- a/ext/cabocha/extconf.rb
+++ b/ext/cabocha/extconf.rb
@@ -7,6 +7,7 @@ enable_config('cabocha-config')
   have_library(lib)
 }
 
-$CFLAGS += ' ' + `#{cabocha_config} --cflags`.chomp
+$CPPFLAGS += ' ' + `#{cabocha_config} --cflags`.chomp
+$LDFLAGS += ' ' + `#{cabocha_config} --libs`.chomp
 
 have_header('cabocha.h') && create_makefile('cabocha/CaboCha')


### PR DESCRIPTION
This PR for fixing #1.
- Changed CFLAGS to CPPFLAGS, because generated MakeFile uses CPPFLAGS instead of CFLAGS like below.

```
.cpp.o:
        $(ECHO) compiling $(<)
        $(Q) $(CXX) $(INCFLAGS) $(CPPFLAGS) $(CXXFLAGS) $(COUTFLAG)$@ -c $<
```
- Added LDFLAGS for linking libraries.
- When first install, there is no `cabocha/CaboCha`, so `require 'cabocha'` on gemspec  always failed. (and I think you should not treat cabocha-ruby in the same version as CaboCha.)
